### PR TITLE
Remove pandas dependency and clean functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 movies-db-csv/
 _db_*/
 *.csv
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 license = {file = "LICENSE.md"}
 dependencies = [
   "yfiles_jupyter_graphs>=1.10.0",
-  "pandas>=1.0.0"
 ]
 
 [project.urls]
@@ -35,3 +34,8 @@ Repository = "https://github.com/yWorks/yfiles-jupyter-graphs-for-kuzu.git"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = [
+    "ipykernel>=6.29.5",
+]


### PR DESCRIPTION
This PR does the following:

1. Removes dependency on Pandas (it adds to initial compilation time for the widget during the first run, and there is no inherent benefit to adding it as a dependency). The query result is iterated within Python rather than `df.iterrows`.
2. Handles primary keys more explicitly (it's retrieved from the table info)
   - The parse function now requires access to the connection object, referenced by `self._connection` and it is thus no longer a static method
3. Only returns the properties that are present in the given node table (earlier version returned all properties with `null` values). So the hover box now shows more useful information to the user.
4. Adds a `clean_value` helper function to handle Python datetimes
   - It's quite common in graphs to have a `datetime` object stored as a property on a node
   - When this is returned from Kuzu in Python, it's obtained as a Python `datetime`, which isn't parseable as JSON and the notebook widget complains. The `clean_value` method handles this by parsing the datetime as an ISO-8601 formatted string