### PR TITLE
Support recursive Cypher queries

### DIFF
--- a/src/yfiles_jupyter_graphs_for_kuzu/Yfiles_Kuzu_Graphs.py
+++ b/src/yfiles_jupyter_graphs_for_kuzu/Yfiles_Kuzu_Graphs.py
@@ -135,13 +135,13 @@ class KuzuGraphWidget:
                     continue
 
                 # Process nodes
-                if isinstance(value, dict) and "_label" in value and "_id" in value and not ("_src" in value and "_dst" in value):
+                if "_label" in value and "_id" in value and not ("_src" in value and "_dst" in value):
                     _id = value["_id"]
                     node_map[(_id["table"], _id["offset"])] = value
                     table_to_label_dict[_id["table"]] = value["_label"]
 
                 # Process relationships
-                elif isinstance(value, dict) and "_label" in value and "_src" in value and "_dst" in value:
+                elif "_label" in value and "_src" in value and "_dst" in value:
                     # Remove None values from the relationship
                     for key in list(value.keys()):
                         if value[key] is None:
@@ -150,7 +150,7 @@ class KuzuGraphWidget:
                     relationship_map[encode_rel_id(value)] = value
 
                 # Process recursive relationships and their associated nodes
-                elif isinstance(value, dict) and "_nodes" in value and "_rels" in value:
+                elif "_nodes" in value and "_rels" in value:
                     recursive_nodes = value["_nodes"]
                     for node in recursive_nodes:
                         _id = node["_id"]

--- a/src/yfiles_jupyter_graphs_for_kuzu/Yfiles_Kuzu_Graphs.py
+++ b/src/yfiles_jupyter_graphs_for_kuzu/Yfiles_Kuzu_Graphs.py
@@ -4,7 +4,6 @@ The main KuzuGraphWidget class is defined in this module.
 
 """
 from typing import Any, Callable, Dict, Union, Optional, List, Tuple
-from types import FunctionType, MethodType
 import inspect
 from datetime import date, datetime
 

--- a/src/yfiles_jupyter_graphs_for_kuzu/Yfiles_Kuzu_Graphs.py
+++ b/src/yfiles_jupyter_graphs_for_kuzu/Yfiles_Kuzu_Graphs.py
@@ -149,6 +149,23 @@ class KuzuGraphWidget:
 
                     relationship_map[encode_rel_id(value)] = value
 
+                # Process recursive relationships and their associated nodes
+                elif isinstance(value, dict) and "_nodes" in value and "_rels" in value:
+                    recursive_nodes = value["_nodes"]
+                    for node in recursive_nodes:
+                        _id = node["_id"]
+                        node_map[(_id["table"], _id["offset"])] = node
+                        table_to_label_dict[_id["table"]] = node["_label"]
+
+                    recursive_rels = value["_rels"]
+                    for rel in recursive_rels:
+                        # Remove None values from the relationship
+                        for key in list(rel.keys()):
+                            if rel[key] is None:
+                                del rel[key]
+
+                        relationship_map[encode_rel_id(rel)] = rel
+
         # Convert nodes to the result format
         result_nodes = []
         for node in node_map.values():


### PR DESCRIPTION
This PR does the following:
- Extends the functionality of the Kuzu graph widget to support undirected/directed recursive join queries in Cypher.
- Captures the subgraph returned when the query contains the Kleene star
- Adds node and relationship mappings when the returned query results contain [RECURSIVE_REL](https://docs.kuzudb.com/cypher/data-types/#recursive_rel) types in Kuzu
- Removes a redundant type check query result. A query results's internal items in Python are always dicts, so we don't need to check for this

## Example query

On a sample dataset, I tested using this query (undirected recursive join):
```cypher
g.show_cypher("MATCH (a:Person {name: 'Rebecca Griffin'})-[r:Follows*1..2]-(b:Person) RETURN * LIMIT 50")
```
The same works with directed queries too, and the prior functionality is unaffected.

![image](https://github.com/user-attachments/assets/5246d7dd-070a-49fd-ade9-b222fb10cd76)
